### PR TITLE
FIx context menu location

### DIFF
--- a/src/pill.rs
+++ b/src/pill.rs
@@ -21,8 +21,8 @@ pub fn pill(props: &PillProps) -> Html {
             event.prevent_default();
             event.set_cancel_bubble(true);
             context_menu.dispatch(ContextMenuAction::Show(
-                event.client_x(),
-                event.client_y(),
+                event.page_x(),
+                event.page_y(),
                 items.clone(),
             ))
         }


### PR DESCRIPTION
If you scroll then right-click a pill, previously the context menu was displayed incorrectly relative to the viewport, not to the whole page. This meant we had to scroll up to see the menu.